### PR TITLE
Switch condition for set_fixed_type

### DIFF
--- a/goaldis/machine.cpp
+++ b/goaldis/machine.cpp
@@ -153,7 +153,7 @@ void set_fixed_type(FixedSym id, const char *name, symbol *parentTypeSym, uint64
 
 	// we can narrow the number of methods if needed, but not expand outside what we allocated.
 	int num_methods = (flags>>32)&0xffff;
-	if (num_methods < type->allocated_length)
+	if (type->allocated_length < num_methods)
 		type->allocated_length = num_methods;
 
 	if (!print_fn)


### PR DESCRIPTION
I think it's

```
slt a1, a0, v1   ;a0 is type->allocated, v1 is shifted flags
beqz a1, flags_larger_than_type
move a0, v1
flags_larger_than_type:
andi v1, a0, 0xffff
sh v1, 0xe(v0) ;v0 is type
```


Additionally, the "unknown_fn" returns a size used when copying, if you were curious....